### PR TITLE
[FIX] Adapt gene symbol parsing and filtering functionality to new VEP version

### DIFF
--- a/src/neoepitopeprediction.py
+++ b/src/neoepitopeprediction.py
@@ -104,14 +104,13 @@ def read_variant_effect_predictor(file, gene_filter=None):
                 try:
                     #Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|TSL|APPRIS|SIFT|PolyPhen|AF|AFR_AF|AMR_AF|EAS_AF|EUR_AF|SAS_AF|AA_AF|EA_AF|gnomAD_AF|gnomAD_AFR_AF|gnomAD_AMR_AF|gnomAD_ASJ_AF|gnomAD_EAS_AF|gnomAD_FIN_AF|gnomAD_NFE_AF|gnomAD_OTH_AF|gnomAD_SAS_AF|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE">
                     _,var_type,_,gene,_,transcript_type,transcript_id,_,_,_,_,_,_,transcript_pos,prot_pos,aa_mutation = co.strip().split("|")[:16]
-                    HGNC_ID=co.strip().split("|")[22]
                 except ValueError:
                     logging.warning("INFO field in different format in line: {}, skipping...".format(str(i)))
                     continue
 
                 #pass every other feature type except Transcript (RegulatoryFeature, MotifFeature.)
                 #pass genes that are uninterresting for us
-                if transcript_type != "Transcript" or (HGNC_ID not in gene_filter and gene_filter):
+                if transcript_type != "Transcript" or (gene not in gene_filter and gene_filter):
                     continue
 
                 #pass all intronic and other mutations that do not directly influence the protein sequence
@@ -120,7 +119,7 @@ def read_variant_effect_predictor(file, gene_filter=None):
 
                     #positioning in Fred2 is 0-based!!!
                     if transcript_pos != "" and '?' not in transcript_pos:
-                        coding[transcript_id] = MutationSyntax(transcript_id, int(transcript_pos.split("-")[0])-1, -1 if prot_pos  == "" else int(prot_pos.split("-")[0])-1, co, "", geneID=HGNC_ID)
+                        coding[transcript_id] = MutationSyntax(transcript_id, int(transcript_pos.split("-")[0])-1, -1 if prot_pos  == "" else int(prot_pos.split("-")[0])-1, co, "", geneID=gene)
                 #is variant synonymous?
                 isSynonymous = any(t == "synonymous_variant" for t in var_type.split("&"))
 


### PR DESCRIPTION
The position of (GENE) SYMBOL annotations has been changed in newer versions of VEP (tested with v90 and v92).

According to a comment it used to be:
_#Allele|Gene|Feature|Feature_type|Consequence|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|SYMBOL|SYMBOL_SOURCE|HGNC_ID|CCDS">_

Now it is as follows according to the [VEP documentation](https://www.ensembl.org/info/docs/tools/vep/vep_formats.html):
_Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID_

This has already been changed in PR #15. But instead of the GENE SYMBOL, the HGNC ID has been parsed, therefore the variant gene filter (by gene name) did not work anymore. 

Since, we want to the display the gene symbol in the output, the geneID in the MutationSyntax has to be changed to 'gene' as well.
