### PR TITLE
neoepitopeprediction.py error: change filename and ctd

### DIFF
--- a/knime/descriptors/neoepitopeprediction.ctd
+++ b/knime/descriptors/neoepitopeprediction.ctd
@@ -8,7 +8,7 @@
 	
 	Please cite the original publication of the used prediction method alongside ImmunoNodes.
 	</description>
-	<executableName>neopeitopeprediction.py</executableName>
+	<executableName>neoepitopeprediction.py</executableName>
 	<PARAMETERS version="1.6.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://github.com/genericworkflownodes/CTDopts/raw/master/schemas/Param_1_6_2.xsd">
 		<NODE description="Commandline tool for epitope prediction" name="NeoEpitopePredicton">
 			<ITEM description="Version of the tool that generated this parameters file." name="version" restrictions="1.0" tags="advanced" type="string" value="1.0"/>


### PR DESCRIPTION
Running the neoepitopeprediction node resulted in the following error:

Failing process stderr: [/usr/local/bin/docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"neopeitopeprediction.py\": executable file not found in $PATH": unknown.]

reason seems to be a typo in the ctd and filename