### PR TITLE
changed filter arguments from bool to string

### DIFF
--- a/src/neoepitopeprediction.py
+++ b/src/neoepitopeprediction.py
@@ -186,19 +186,22 @@ def main():
 
     model.add_argument(
         '-fINDEL' ,'--filterINDEL',
-        action="store_true",
+        type=str,
+        default='true',
         help='Filter insertions and deletions (including frameshifts)'
         )
 
     model.add_argument(
         '-fFS' ,'--filterFSINDEL',
-        action="store_true",
+        type=str,
+        default='true',
         help='Filter frameshift INDELs'
         )
 
     model.add_argument(
         '-fSNP' ,'--filterSNP',
-        action="store_true",
+        type=str,
+        default='false',
         help='Filter SNPs'
         )
 
@@ -241,16 +244,16 @@ def main():
 
         variants = filter(lambda x: x.type != VariationType.UNKNOWN, variants)
 
-        if args.filterSNP:
+        if args.filterSNP == 'true':
             variants = filter(lambda x: x.type != VariationType.SNP, variants)
 
-        if args.filterINDEL:
+        if args.filterINDEL == 'true':
             variants = filter(lambda x: x.type not in [VariationType.INS,
                                                        VariationType.DEL,
                                                        VariationType.FSDEL,
                                                        VariationType.FSINS], variants)
 
-        if args.filterFSINDEL:
+        if args.filterFSINDEL == 'true':
             variants = filter(lambda x: x.type not in [VariationType.FSDEL, VariationType.FSINS], variants)
 
         if not variants:

--- a/src/variants2proteins.py
+++ b/src/variants2proteins.py
@@ -153,19 +153,22 @@ def main():
 
     model.add_argument(
         '-fINDEL' ,'--filterINDEL',
-        action="store_true",
+        type=str,
+        default='true',
         help='Filter insertions and deletions (including frameshifts)'
         )
 
     model.add_argument(
         '-fFS' ,'--filterFSINDEL',
-        action="store_true",
+        type=str,
+        default='true',
         help='Filter frameshift INDELs'
         )
 
     model.add_argument(
         '-fSNP' ,'--filterSNP',
-        action="store_true",
+        type=str,
+        default='false',
         help='Filter SNPs'
         )
 
@@ -206,16 +209,16 @@ def main():
             variants = read_annovar_exonic(args.vcf, gene_filter=protein_ids)
 
 
-        if args.filterSNP:
+        if args.filterSNP == 'true':
             variants = filter(lambda x: x.type != VariationType.SNP, variants)
 
-        if args.filterINDEL:
+        if args.filterINDEL == 'true':
             variants = filter(lambda x: x.type not in [VariationType.INS,
                                                        VariationType.DEL,
                                                        VariationType.FSDEL,
                                                        VariationType.FSINS], variants)
 
-        if args.filterFSINDEL:
+        if args.filterFSINDEL == 'true':
             variants = filter(lambda x: x.type not in [VariationType.FSDEL, VariationType.FSINS], variants)
 
         if not variants:


### PR DESCRIPTION
When running in KNIME, I got the following error:

```
ERROR NeoEpitopePredicton  0:180      Failing process stdout: []
ERROR NeoEpitopePredicton  0:180      Failing process stderr: [usage: neoepitopeprediction.py [-h],                                [-m {netmhcstabpan,smmpmbec,syfpeithi,netmhc,netctlpan,smm,tepitopepan,netmhcii,arb,pickpocket,epidemix,unitope,netmhciipan,comblibsidney,netmhcpan,calisimm,hammer,svmhc,bimas}],                                [-v VCF] [-t {VEP,ANNOVAR,SNPEFF}],                                [-p PROTEINS],                                [-l {8,9,10,11,12,13,14,15,16,17}] -a ALLELES,                                [-r REFERENCE] [-fINDEL] [-fFS] [-fSNP] -o,                                OUTPUT,
neoepitopeprediction.py: error: unrecognized arguments:  true]
ERROR NeoEpitopePredicton  0:180      Execute failed: Failed to execute node NeoEpitopePredicton
```

After checking the script manually I suspect that knime overgives the filter parameters as strings instead of booleans. Thats why it doesnt recognize the true argument.

