### PR TITLE
SNPEFF capitals

### DIFF
--- a/src/variants2proteins.py
+++ b/src/variants2proteins.py
@@ -132,7 +132,7 @@ def main():
     model.add_argument(
         '-t', '--type',
         type=str,
-        choices=["VEP", "ANNOVAR", "SnpEff"],
+        choices=["VEP", "ANNOVAR", "SNPEFF"],
         default="VEP",
         help='Type of annotation tool used (Variant Effect Predictor, ANNOVAR exonic gene annotation, SnpEff)'
         )


### PR DESCRIPTION
Discovered another small bug in the new Variants2Proteins node

`ERROR Variants2Proteins    0:179      Failing process stderr: [usage: variants2proteins.py [-h] [-v VCF] [-t {VEP,ANNOVAR,SnpEff}],                             [-p PROTEINS] [-r REFERENCE] [-fINDEL] [-fFS],                             [-fSNP] -o OUTPUT, variants2proteins.py: error: argument -t/--type: invalid choice: 'SNPEFF' (choose from 'VEP', 'ANNOVAR', 'SnpEff')]
`